### PR TITLE
Refresh packages and template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:1.3.5
+FROM semtech/mu-javascript-template:1.6.0
 LABEL maintainer="info@redpencil"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Oscar <lagartoverde97@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@lblod/mu-auth-sudo": "^0.2.0",
-    "node-cron": "^2.0.3"
+    "@lblod/mu-auth-sudo": "^0.6.1",
+    "node-cron": "^3.0.2"
   }
 }


### PR DESCRIPTION
I was using this service to write some reports, and I noticed that certain syntax features where not working because the JavaScript version was too old. Time for an update?

This PR bumps the template version to 1.6.0 (not latest, but already an improvement) and bumps all packages to their latest version.

I don't think this would cause an issue with the scripts that are already in use. If so, those stacks are still free to use a version of this service before the 1.6.0 upgrade.