### PR TITLE
Remove unmatched quotes

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -9,8 +9,12 @@ export function generateCSV(fields, data) {
   const headerString = fields.join(separator);
   const csvRows = data.map((row) => {
     return fields.map((propertyName) => {
-      const dt = row[propertyName] || '';
-      return dt.includes(separator) ? `"${dt}"` : dt;
+      let dt = row[propertyName] || '';
+      //Remove unmatched double quotes
+      dt = [...dt.matchAll(/"/g)].length % 2 !== 0 ? dt.replace(/"/g, '') : dt;
+      //Escape the use of the semicolon
+      dt = dt.includes(separator) ? `"${dt}"` : dt;
+      return dt;
     }).join(separator);
   });
   return `${headerString}\n${csvRows.join('\n')}`;


### PR DESCRIPTION
With a dirty quote `"` that is not matched, most CSV parsers wil interpret this as the start of a literal. All the following data will be considered data for the same "cell". In this case there is not much more we can do than just remove all the quotes. In other cases (matched quotes), they can safely stay.