### PR TITLE
Ensure folder exists before creating report

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -108,7 +108,14 @@ export async function generateReportFromData(data, attributes, reportInfo) {
   const fileExtension = 'csv';
   const fileFormat = 'text/csv';
   const csv = generateCSV(attributes, data);
-  fs.writeFileSync(`/share/${fileName}.${fileExtension}`, csv);
+  const filePath = `/share/${fileName}.${fileExtension}`;
+  let outputDirectory = filePath.split('/');
+  outputDirectory.pop();
+  outputDirectory = outputDirectory.join('/');
+
+  fs.mkdirSync(outputDirectory, { recursive: true });
+  fs.writeFileSync(filePath, csv);
+
   const fileStats = fs.statSync(`/share/${fileName}.${fileExtension}`);
   const fileInfo = {
     name: fileName,


### PR DESCRIPTION
When providing a path to the `filePrefix` option in a report, if the configured subfolder(s) don't exist, the file creation fails. We have to manually create the folder, commit it etc.

This change makes sure that the entire path of folders exists before creating a report.