### PR TITLE
Add option to auto delete previous versions of a report

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ written to. The path is important because it is related to the file info
 written to the database. The other volume, mounted to `/config` is where the
 report code will be (the `index.js` file, see below).
 
+## Environment variables
+
+The following enviroment variables can be configured:
+* `DEFAULT_GRAPH`: Default graph in which the file will be stored in the db. Defaults to `http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/LoketAdmin`
+* `ONLY_KEEP_LATEST_REPORT`: Boolean that allows, when set to `true`, to only keep the most recent version of a report during its creation and to delete oder versions. Defaults to `false`
 
 ## Defining reports
 

--- a/config.js
+++ b/config.js
@@ -1,2 +1,17 @@
+import * as env from 'env-var';
+
 export const CREATOR =
   'http://lblod.data.gift/services/loket-report-generation-service';
+
+export const DEFAULT_GRAPH = env
+  .get('DEFAULT_GRAPH')
+  .required()
+  .default(
+    'http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b/LoketAdmin',
+  )
+  .asUrlString();
+
+export const ONLY_KEEP_LATEST_REPORT = env
+  .get('ONLY_KEEP_LATEST_REPORT')
+  .default('false')
+  .asBool();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loket-report-generation-service",
-  "version": "0.6.3",
+  "version": "0.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "loket-report-generation-service",
-      "version": "0.6.3",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
         "@lblod/mu-auth-sudo": "^0.6.1",


### PR DESCRIPTION
Auto-deletes older versions a report when a new version of it gets created. This prevents the server to be overloaded with old data dumps.

The default behavior doesn't change, this option needs to be activated via an environment variable.