### PR TITLE
Fix report generation endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,43 +20,47 @@ try {
   );
 }
 
-app.post('/reports', async (req, res) => {
-  const reportName = req.body.data.attributes.reportName;
-  if (reportName) {
-    let report = reports.find((report) => report.name === reportName);
-    if (report) {
-      report.execute();
-      return res.json({
-        data: {
-          type: 'report-generation-tasks',
-          attributes: {
-            status: 'success',
+app.post('/reports', async (req, res, next) => {
+  try {
+    const reportName = req.body.data.attributes.reportName;
+    if (reportName) {
+      let report = reports.find((report) => report.name === reportName);
+      if (report) {
+        await report.execute();
+        return res.json({
+          data: {
+            type: 'report-generation-tasks',
+            attributes: {
+              status: 'success',
+            },
           },
-        },
-      });
+        });
+      } else {
+        res.status(404);
+        return res.json({
+          data: {
+            type: 'report-generation-tasks',
+            attributes: {
+              status: 'error',
+              info: `There's no report named ${reportName}`,
+            },
+          },
+        });
+      }
     } else {
-      res.status(404);
+      res.status(400);
       return res.json({
         data: {
           type: 'report-generation-tasks',
           attributes: {
             status: 'error',
-            info: `There's no report named ${reportName}`,
+            info: 'No report name specified in the request',
           },
         },
       });
     }
-  } else {
-    res.status(400);
-    return res.json({
-      data: {
-        type: 'report-generation-tasks',
-        attributes: {
-          status: 'error',
-          info: 'No report name specified in the request',
-        },
-      },
-    });
+  } catch (e) {
+    next(e);
   }
 });
 


### PR DESCRIPTION
## Context 

`/reports` endpoint returns `success` without waiting the end of `report.execute`. 

## Changes 

- Add `await` on `report.execute`
- Wrap in a `try/catch` and redirect error in `next` as describe here: https://github.com/mu-semtech/mu-javascript-template#error-handling