### PR TITLE
Change and add some escaped characters

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -17,11 +17,13 @@ export function generateCSV(fields, data) {
     return fields
       .map((propertyName) => {
         let dt = row[propertyName] || '';
-        //Remove unmatched double quotes
-        dt =
-          [...dt.matchAll(/"/g)].length % 2 !== 0 ? dt.replace(/"/g, '') : dt;
+        //Escape the use of double quotes by prepending a quote
+        dt = dt.replace(/"/g, '""');
         //Escape the use of the semicolon
         dt = dt.includes(SEPARATOR) ? `"${dt}"` : dt;
+        //Escape newlines and tabs
+        dt = dt.replace(/\n/g, '\\n');
+        dt = dt.replace(/\t/g, '\\t');
         return dt;
       })
       .join(SEPARATOR);


### PR DESCRIPTION
Unmatched quotes don't need to be removed if you can "escape" them. In CSV, this in done by prepending them with an extra quote, according to the [CSV specification](https://www.rfc-editor.org/rfc/rfc4180).

Newlines and tabs are now escaped with the usual backspace method. This is not according to the spec, but not wrong either and I presume we can allow this for our specific use case. The reason for this is that Excel might not like newlines inside fields, thinking it means the start of a new record, which messes up the reports.

There might be more cases that need to be escaped, but because we see no more errors in our reports, hunting down all edge cases is out of scope for now. If CSV correctness is required one day, we should rather be thinking of using a CSV library.