### PR TITLE
Delete report and its results in batches

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -935,6 +935,40 @@ export async function deletePreviousShaclValidationReports(namedGraphs) {
   }
 }
 
+async function deleteShaclValidationResultBatch(
+  safeReportUri,
+  safeNamedGraphs,
+  batchNumber,
+) {
+  // Fetch a batch of result URIs
+  const batchResponse = await querySudo(`
+    PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+    SELECT DISTINCT ?result
+    WHERE {
+      VALUES ?g { ${safeNamedGraphs} }
+      GRAPH ?g { ${safeReportUri} sh:result ?result . }
+    }
+    LIMIT ${INSERT_BATCH_SIZE}
+    OFFSET ${batchNumber * INSERT_BATCH_SIZE}
+  `);
+  const safeResults = batchResponse.results.bindings
+    .map((b) => sparqlEscapeUri(b.result.value))
+    .join('\n');
+
+  if (safeResults) {
+    await querySudo(`
+      DELETE {
+        GRAPH ?g { ?result ?p ?o . }
+      }
+      WHERE {
+        VALUES ?g { ${safeNamedGraphs} }
+        VALUES ?result { ${safeResults} }
+        GRAPH ?g { ?result ?p ?o . }
+      }
+    `);
+  }
+}
 async function deleteShaclValidationReportInDatabase(reportUri, namedGraphs) {
   const safeNamedGraphs = namedGraphs.map((g) => sparqlEscapeUri(g)).join('\n');
   const safeReportUri = sparqlEscapeUri(reportUri);
@@ -956,34 +990,7 @@ async function deleteShaclValidationReportInDatabase(reportUri, namedGraphs) {
   const batchCount = Math.ceil(total / INSERT_BATCH_SIZE);
 
   for (let i = 0; i < batchCount; i++) {
-    // Fetch a batch of result URIs
-    const batchResponse = await querySudo(`
-      PREFIX sh: <http://www.w3.org/ns/shacl#>
-
-      SELECT DISTINCT ?result
-      WHERE {
-        VALUES ?g { ${safeNamedGraphs} }
-        GRAPH ?g { ${safeReportUri} sh:result ?result . }
-      }
-      LIMIT ${INSERT_BATCH_SIZE}
-      OFFSET ${i * INSERT_BATCH_SIZE}
-    `);
-    const safeResults = batchResponse.results.bindings
-      .map((b) => sparqlEscapeUri(b.result.value))
-      .join('\n');
-
-    if (safeResults) {
-      await querySudo(`
-        DELETE {
-          GRAPH ?g { ?result ?p ?o . }
-        }
-        WHERE {
-          VALUES ?g { ${safeNamedGraphs} }
-          VALUES ?result { ${safeResults} }
-          GRAPH ?g { ?result ?p ?o . }
-        }
-      `);
-    }
+    await deleteShaclValidationResultBatch(safeReportUri, safeNamedGraphs, i);
   }
 
   // Report can have thousands of validation result triples

--- a/helpers.js
+++ b/helpers.js
@@ -998,23 +998,24 @@ async function deleteShaclValidationReportInDatabase(reportUri, namedGraphs) {
     `);
     reportExists = askResponse.boolean;
 
-    if (!reportExists) break;
-    await querySudo(`
-      DELETE {
-        GRAPH ?g { ${safeReportUri} ?p ?o . }
-      }
-      WHERE {
-        VALUES ?g { ${safeNamedGraphs} }
-        {
-          SELECT ?p ?o WHERE {
-            VALUES ?g { ${safeNamedGraphs} }
-            GRAPH ?g { ${safeReportUri} ?p ?o . }
-          }
-          LIMIT ${INSERT_BATCH_SIZE}
+    if (reportExists) {
+      await querySudo(`
+        DELETE {
+          GRAPH ?g { ${safeReportUri} ?p ?o . }
         }
-        GRAPH ?g { ${safeReportUri} ?p ?o . }
-      }
-    `);
+        WHERE {
+          VALUES ?g { ${safeNamedGraphs} }
+          {
+            SELECT ?p ?o WHERE {
+              VALUES ?g { ${safeNamedGraphs} }
+              GRAPH ?g { ${safeReportUri} ?p ?o . }
+            }
+            LIMIT ${INSERT_BATCH_SIZE}
+          }
+          GRAPH ?g { ${safeReportUri} ?p ?o . }
+        }
+      `);
+    }
   }
 }
 

--- a/helpers.js
+++ b/helpers.js
@@ -936,45 +936,86 @@ export async function deletePreviousShaclValidationReports(namedGraphs) {
 }
 
 async function deleteShaclValidationReportInDatabase(reportUri, namedGraphs) {
-  // done in two parts because single query confuses db because of join result set explosion
-  const queryDeleteResults = `
+  const safeNamedGraphs = namedGraphs.map((g) => sparqlEscapeUri(g)).join('\n');
+  const safeReportUri = sparqlEscapeUri(reportUri);
+
+  // Count results to determine number of batches
+  const countResponse = await querySudo(`
     PREFIX sh: <http://www.w3.org/ns/shacl#>
 
-    DELETE {
-      GRAPH ?g {
-        ?result ?presult ?oresult .
-      }
-    }
+    SELECT (COUNT(DISTINCT ?result) AS ?count)
     WHERE {
-      VALUES ?g {
-        ${namedGraphs.map((g) => sparqlEscapeUri(g)).join('\n')}
-      }
-      GRAPH ?g {
-        ${sparqlEscapeUri(reportUri)} sh:result ?result .
-
-        ?result ?presult ?oresult .
-      }
+      VALUES ?g { ${safeNamedGraphs} }
+      GRAPH ?g { ${safeReportUri} sh:result ?result . }
     }
-  `;
-  await querySudo(queryDeleteResults);
-  const queryString = `
-        PREFIX sh: <http://www.w3.org/ns/shacl#>
+  `);
+  const total = parseInt(
+    countResponse.results.bindings[0]?.count?.value ?? '0',
+    10,
+  );
+  const batchCount = Math.ceil(total / INSERT_BATCH_SIZE);
 
-        DELETE {
-          GRAPH ?g {
-            ${sparqlEscapeUri(reportUri)} ?preport ?oreport .
+  for (let i = 0; i < batchCount; i++) {
+    // Fetch a batch of result URIs
+    const batchResponse = await querySudo(`
+      PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+      SELECT DISTINCT ?result
+      WHERE {
+        VALUES ?g { ${safeNamedGraphs} }
+        GRAPH ?g { ${safeReportUri} sh:result ?result . }
+      }
+      LIMIT ${INSERT_BATCH_SIZE}
+      OFFSET ${i * INSERT_BATCH_SIZE}
+    `);
+    const safeResults = batchResponse.results.bindings
+      .map((b) => sparqlEscapeUri(b.result.value))
+      .join('\n');
+
+    if (!safeResults) continue;
+
+    await querySudo(`
+      DELETE {
+        GRAPH ?g { ?result ?p ?o . }
+      }
+      WHERE {
+        VALUES ?g { ${safeNamedGraphs} }
+        VALUES ?result { ${safeResults} }
+        GRAPH ?g { ?result ?p ?o . }
+      }
+    `);
+  }
+
+  // Report can have thousands of validation result triples
+  // Here we delete these triples in batches
+  let reportExists = true;
+  while (reportExists) {
+    const askResponse = await querySudo(`
+      ASK {
+        VALUES ?g { ${safeNamedGraphs} }
+        GRAPH ?g { ${safeReportUri} ?p ?o . }
+      }
+    `);
+    reportExists = askResponse.boolean;
+
+    if (!reportExists) break;
+    await querySudo(`
+      DELETE {
+        GRAPH ?g { ${safeReportUri} ?p ?o . }
+      }
+      WHERE {
+        VALUES ?g { ${safeNamedGraphs} }
+        {
+          SELECT ?p ?o WHERE {
+            VALUES ?g { ${safeNamedGraphs} }
+            GRAPH ?g { ${safeReportUri} ?p ?o . }
           }
+          LIMIT ${INSERT_BATCH_SIZE}
         }
-        WHERE {
-          VALUES ?g {
-            ${namedGraphs.map((g) => sparqlEscapeUri(g)).join('\n')}
-          }
-          GRAPH ?g {
-            ${sparqlEscapeUri(reportUri)} ?preport ?oreport .
-          }
-        }
-    `;
-  await querySudo(queryString);
+        GRAPH ?g { ${safeReportUri} ?p ?o . }
+      }
+    `);
+  }
 }
 
 /**

--- a/helpers.js
+++ b/helpers.js
@@ -972,18 +972,18 @@ async function deleteShaclValidationReportInDatabase(reportUri, namedGraphs) {
       .map((b) => sparqlEscapeUri(b.result.value))
       .join('\n');
 
-    if (!safeResults) continue;
-
-    await querySudo(`
-      DELETE {
-        GRAPH ?g { ?result ?p ?o . }
-      }
-      WHERE {
-        VALUES ?g { ${safeNamedGraphs} }
-        VALUES ?result { ${safeResults} }
-        GRAPH ?g { ?result ?p ?o . }
-      }
-    `);
+    if (safeResults) {
+      await querySudo(`
+        DELETE {
+          GRAPH ?g { ?result ?p ?o . }
+        }
+        WHERE {
+          VALUES ?g { ${safeNamedGraphs} }
+          VALUES ?result { ${safeResults} }
+          GRAPH ?g { ?result ?p ?o . }
+        }
+      `);
+    }
   }
 
   // Report can have thousands of validation result triples


### PR DESCRIPTION
# Description
Currently, at the end of the validation, each previous report with results get deleted using two queries. First, all result triples of one report get deleted. Then, the report triples itself. However, when there are thousands of decisions (100k+) and one property fails, then a report also contains thousands of triples and x times more result triples. This results in too heavy queries.

This PR adds batching to these two queries.
For each report:
- Retrieve count of validation results and perform in batches:
- Fetch a batch of these validation results
- delete all triples of these validation results

When all results are deleted, delete all triples of report in batches by checking each time whether there are still triples left

# How to test

- download latest datadump from test server (for example: db-20260623.tar.gz)
- Check reports with number of results. There should always be 1 (latest) report available 
```
prefix sh: <http://www.w3.org/ns/shacl#>

select ?s (count(distinct ?result) as ?c)
where {
?s a sh:ValidationReport ;
sh:result ?result .
}
group by ?s
```
<img width="1448" height="798" alt="image" src="https://github.com/user-attachments/assets/33f66e44-c2f0-49de-9809-f1ff07773a5b" />

- make sure report-generation service is running with this version (https://github.com/lblod/loket-report-generation-service/pull/21). In your docker-compose.override.yml:
```
report-generation:
    environment:
      NODE_ENV: "development"
      RUN_REPORT_NOW: "true"
    volumes:
      - /Users/brechtvandevyvere/Documents/loket-report-generation-service/:/app
```
- Check logs for its status: `drc logs report-generation`. After +/- 15 minutes, the process should log "Done validating.": 
<img width="1273" height="621" alt="image" src="https://github.com/user-attachments/assets/fdf045dd-8979-440c-bbfb-3f1516c9870d" />

- Retry the query above, should result in 1 report:
<img width="2238" height="251" alt="image" src="https://github.com/user-attachments/assets/d9a790ad-de8a-4860-a474-99418df1189b" />


